### PR TITLE
style: aplicar formato automático con Prettier en todo el proyecto

### DIFF
--- a/__tests__/domain/entities/podcast.test.ts
+++ b/__tests__/domain/entities/podcast.test.ts
@@ -7,11 +7,11 @@ describe('transformPodcasts', () => {
       feed: {
         entry: [
           {
-            id: { attributes: { "im:id": "1" } },
-            "im:name": { label: "Tech Talks" },
-            "im:image": [{ label: "url", attributes: { height: "170" } }],
-            "im:artist": { label: "John Doe" },
-            summary: { label: "A podcast about tech" },
+            id: { attributes: { 'im:id': '1' } },
+            'im:name': { label: 'Tech Talks' },
+            'im:image': [{ label: 'url', attributes: { height: '170' } }],
+            'im:artist': { label: 'John Doe' },
+            summary: { label: 'A podcast about tech' },
           },
         ],
       },
@@ -20,11 +20,11 @@ describe('transformPodcasts', () => {
     const podcasts = transformPodcasts(apiResponse);
 
     expect(podcasts).toHaveLength(1);
-    expect(podcasts[0].id).toBe("1");
-    expect(podcasts[0].title).toBe("Tech Talks");
-    expect(podcasts[0].author).toBe("John Doe");
-    expect(podcasts[0].image).toBe("url");
-    expect(podcasts[0].summary).toBe("A podcast about tech");
+    expect(podcasts[0].id).toBe('1');
+    expect(podcasts[0].title).toBe('Tech Talks');
+    expect(podcasts[0].author).toBe('John Doe');
+    expect(podcasts[0].image).toBe('url');
+    expect(podcasts[0].summary).toBe('A podcast about tech');
   });
 
   it('debería filtrar podcasts con datos incompletos', () => {
@@ -32,11 +32,11 @@ describe('transformPodcasts', () => {
       feed: {
         entry: [
           {
-            id: { attributes: { "im:id": "1" } },
-            "im:name": { label: "Tech Talks" },
-            "im:image": [],
-            "im:artist": { label: "John Doe" },
-            summary: { label: "" },
+            id: { attributes: { 'im:id': '1' } },
+            'im:name': { label: 'Tech Talks' },
+            'im:image': [],
+            'im:artist': { label: 'John Doe' },
+            summary: { label: '' },
           },
         ],
       },

--- a/__tests__/presentation/HomePage.test.tsx
+++ b/__tests__/presentation/HomePage.test.tsx
@@ -9,7 +9,9 @@ import { LoadingProvider } from '../../src/shared/context/LoadingContext';
 import { NavigationProvider } from '../../src/podcastManagement/presentation/context/NavigationContext';
 import { PodcastServiceProvider } from '../../src/podcastManagement/infrastructure/context/PodcastServiceContext';
 
-jest.mock('./../../src/podcastManagement/infrastructure/repositories/podcastService');
+jest.mock(
+  './../../src/podcastManagement/infrastructure/repositories/podcastService'
+);
 
 describe('PopularPodcastsPage Component', () => {
   const mockPodcasts = [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "eslint \"./**/*.{js,jsx,ts,tsx}\"",
-    "format": "prettier --write './src/**/*.{js,jsx,ts,tsx}'",
+    "format": "prettier --write .",
     "test": "jest --watchAll",
     "prepare": "husky install"
   },


### PR DESCRIPTION
- Se ejecutó el comando `yarn prettier --check --write .` para ajustar el estilo de los archivos según las configuraciones definidas en el proyecto.
- Este cambio no afecta la lógica ni el funcionamiento de la aplicación, únicamente mejora la consistencia del código.
